### PR TITLE
cuberille invocation fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,180 +1,207 @@
-import { Niivue, NVMeshUtilities } from '@niivue/niivue'
+import { Niivue, NVMeshUtilities } from "@niivue/niivue";
 import {
-  antiAliasCuberille,
-  setPipelinesBaseUrl as setCuberillePipelinesUrl
-} from "@itk-wasm/cuberille"
+  cuberille,
+  setPipelinesBaseUrl as setCuberillePipelinesUrl,
+} from "@itk-wasm/cuberille";
 import {
   repair,
   smoothRemesh,
   keepLargestComponent,
   setPipelinesBaseUrl as setMeshFiltersPipelinesUrl,
-} from "@itk-wasm/mesh-filters"
-import { nii2iwi, iwm2meshCore } from "@niivue/cbor-loader"
+} from "@itk-wasm/mesh-filters";
+import { nii2iwi, iwm2meshCore } from "@niivue/cbor-loader";
 
 function formatNumber(value) {
   if (Math.abs(value) >= 1) {
     // For numbers >= 1, use up to 1 decimal place
-    return value.toFixed(1)
+    return value.toFixed(1);
   } else {
     // For numbers < 1, use up to 3 significant digits
-    return value.toPrecision(3)
+    return value.toPrecision(3);
   }
 }
 
 // Use local, vendored WebAssembly module assets
-const viteBaseUrl = import.meta.env.BASE_URL
-const pipelinesBaseUrl = new URL(`${viteBaseUrl}pipelines`, document.location.origin).href
-setCuberillePipelinesUrl(pipelinesBaseUrl)
-setMeshFiltersPipelinesUrl(pipelinesBaseUrl)
+const viteBaseUrl = import.meta.env.BASE_URL;
+const pipelinesBaseUrl = new URL(
+  `${viteBaseUrl}pipelines`,
+  document.location.origin
+).href;
+setCuberillePipelinesUrl(pipelinesBaseUrl);
+setMeshFiltersPipelinesUrl(pipelinesBaseUrl);
 
 async function main() {
-  const loadingCircle = document.getElementById('loadingCircle')
-  let startTime = null
+  const loadingCircle = document.getElementById("loadingCircle");
+  let startTime = null;
   saveBtn.onclick = function () {
     if (nv1.meshes.length < 1) {
-      window.alert("No mesh open for saving. Use 'Create Mesh'.")
+      window.alert("No mesh open for saving. Use 'Create Mesh'.");
     } else {
-      saveDialog.show()
+      saveDialog.show();
     }
-  }
+  };
   aboutBtn.onclick = function () {
-    window.open("https://github.com/niivue/ct2print", "_blank")
-    }
+    window.open("https://github.com/niivue/ct2print", "_blank");
+  };
   volumeSelect.onchange = function () {
-    const selectedOption = volumeSelect.options[volumeSelect.selectedIndex]
-    const txt = selectedOption.text
-    let fnm = './' + txt
+    const selectedOption = volumeSelect.options[volumeSelect.selectedIndex];
+    const txt = selectedOption.text;
+    let fnm = "./" + txt;
     if (volumeSelect.selectedIndex > 4) {
-      fnm = 'https://niivue.github.io/niivue/images/' + txt
+      fnm = "https://niivue.github.io/niivue/images/" + txt;
     } else if (volumeSelect.selectedIndex > 1) {
-      fnm = 'https://niivue.github.io/niivue-demo-images/' + txt
+      fnm = "https://niivue.github.io/niivue-demo-images/" + txt;
     }
     if (nv1.meshes.length > 0) {
-      nv1.removeMesh(nv1.meshes[0])
+      nv1.removeMesh(nv1.meshes[0]);
     }
     if (nv1.volumes.length > 0) {
-      nv1.removeVolumeByIndex(0)
+      nv1.removeVolumeByIndex(0);
     }
     if (volumeSelect.selectedIndex > 5) {
-      nv1.loadMeshes([{ url: fnm }])
+      nv1.loadMeshes([{ url: fnm }]);
     } else {
-      if (!fnm.endsWith('.mgz')) {
-        fnm += '.nii.gz'
+      if (!fnm.endsWith(".mgz")) {
+        fnm += ".nii.gz";
       }
-      nv1.loadVolumes([{ url: fnm }])
+      nv1.loadVolumes([{ url: fnm }]);
     }
-  }
+  };
   applySaveBtn.onclick = function () {
     if (nv1.meshes.length < 1) {
-      return
+      return;
     }
-    let format = "obj"
+    let format = "obj";
     if (formatSelect.selectedIndex === 0) {
-      format = "mz3"
+      format = "mz3";
     }
     if (formatSelect.selectedIndex === 2) {
-      format = "stl"
+      format = "stl";
     }
-    const scale = 1 / Number(scaleSelect.value)
-    const pts = nv1.meshes[0].pts.slice()
-    for (let i = 0; i < pts.length; i++) pts[i] *= scale
-    NVMeshUtilities.saveMesh(pts, nv1.meshes[0].tris, `mesh.${format}`, true)
-  }
+    const scale = 1 / Number(scaleSelect.value);
+    const pts = nv1.meshes[0].pts.slice();
+    for (let i = 0; i < pts.length; i++) pts[i] *= scale;
+    NVMeshUtilities.saveMesh(pts, nv1.meshes[0].tris, `mesh.${format}`, true);
+  };
   createMeshBtn.onclick = function () {
-    if (nv1.meshes.length > 0) nv1.removeMesh(nv1.meshes[0])
+    if (nv1.meshes.length > 0) nv1.removeMesh(nv1.meshes[0]);
     if (nv1.volumes.length < 1) {
-      window.alert("Image not loaded. Drag and drop an image.")
+      window.alert("Image not loaded. Drag and drop an image.");
     } else {
-      remeshDialog.show()
+      remeshDialog.show();
     }
-  }
+  };
   applyBtn.onclick = async function () {
-    const volIdx = nv1.volumes.length - 1
-    loadingCircle.classList.remove("hidden")
-    meshProcessingMsg.classList.remove("hidden")
-    meshProcessingMsg.textContent = "Generating mesh from segmentation"
-    const hdr = nv1.volumes[volIdx].hdr
-    const img = nv1.volumes[volIdx].img
-    const itkImage = nii2iwi(hdr, img, false)
-    itkImage.size = itkImage.size.map(Number)
-    const isoValue = Number(isoNumber.value)
-    console.log(`volume ${volIdx} dimensions ${itkImage.size} with iso-value ${isoValue}`)
-    console.log(itkImage)
-    const { mesh } = await antiAliasCuberille(itkImage, { noClosing: true })
-    meshProcessingMsg.textContent = "Generating manifold"
-    const { outputMesh: repairedMesh } = await repair(mesh, { maximumHoleArea: 50.0 })
-    meshProcessingMsg.textContent = "Keep largest mesh component"
-    const { outputMesh: largestOnly } = await keepLargestComponent(repairedMesh)
+    const volIdx = nv1.volumes.length - 1;
+    loadingCircle.classList.remove("hidden");
+    meshProcessingMsg.classList.remove("hidden");
+    meshProcessingMsg.textContent = "Generating mesh from segmentation";
+    const hdr = nv1.volumes[volIdx].hdr;
+    const img = nv1.volumes[volIdx].img;
+    const itkImage = nii2iwi(hdr, img, false);
+    itkImage.size = itkImage.size.map(Number);
+    const isoValue = Number(isoNumber.value);
+    console.log(
+      `volume ${volIdx} dimensions ${itkImage.size} with iso-value ${isoValue}`
+    );
+    console.log(itkImage);
+    const { mesh } = await cuberille(itkImage, { isoSurfaceValue: isoValue });
+    meshProcessingMsg.textContent = "Generating manifold";
+    const { outputMesh: repairedMesh } = await repair(mesh, {
+      maximumHoleArea: 50.0,
+    });
+    meshProcessingMsg.textContent = "Keep largest mesh component";
+    const { outputMesh: largestOnly } = await keepLargestComponent(
+      repairedMesh
+    );
     while (nv1.meshes.length > 0) {
-      nv1.removeMesh(nv1.meshes[0])
-     }
-    const initialNiiMesh = iwm2meshCore(largestOnly)
-    const initialNiiMeshBuffer = NVMeshUtilities.createMZ3(initialNiiMesh.positions, initialNiiMesh.indices, false)
-    await nv1.loadFromArrayBuffer(initialNiiMeshBuffer, 'trefoil.mz3')
-    saveMeshBtn.disabled = false
-    meshProcessingMsg.textContent = "Smoothing and remeshing"
-    const smooth = parseInt(smoothSlide.value)
-    const shrink = parseFloat(shrinkPct.value)
-    const { outputMesh: smoothedMesh } = await smoothRemesh(largestOnly, { newtonIterations: smooth, numberPoints: shrink })
-    const niiMesh = iwm2meshCore(smoothedMesh)
-    loadingCircle.classList.add("hidden")
-    meshProcessingMsg.classList.add("hidden")
-    while (nv1.meshes.length > 0) {
-      nv1.removeMesh(nv1.meshes[0])
+      nv1.removeMesh(nv1.meshes[0]);
     }
-    const meshBuffer = NVMeshUtilities.createMZ3(niiMesh.positions, niiMesh.indices, false)
-    await nv1.loadFromArrayBuffer(meshBuffer, 'trefoil.mz3')
-  }
+    const initialNiiMesh = iwm2meshCore(largestOnly);
+    const initialNiiMeshBuffer = NVMeshUtilities.createMZ3(
+      initialNiiMesh.positions,
+      initialNiiMesh.indices,
+      false
+    );
+    await nv1.loadFromArrayBuffer(initialNiiMeshBuffer, "trefoil.mz3");
+    saveBtn.disabled = false;
+    meshProcessingMsg.textContent = "Smoothing and remeshing";
+    const smooth = parseInt(smoothSlide.value);
+    const shrink = parseFloat(shrinkPct.value);
+    const { outputMesh: smoothedMesh } = await smoothRemesh(largestOnly, {
+      newtonIterations: smooth,
+      numberPoints: shrink,
+    });
+    const niiMesh = iwm2meshCore(smoothedMesh);
+    loadingCircle.classList.add("hidden");
+    meshProcessingMsg.classList.add("hidden");
+    while (nv1.meshes.length > 0) {
+      nv1.removeMesh(nv1.meshes[0]);
+    }
+    const meshBuffer = NVMeshUtilities.createMZ3(
+      niiMesh.positions,
+      niiMesh.indices,
+      false
+    );
+    await nv1.loadFromArrayBuffer(meshBuffer, "trefoil.mz3");
+  };
 
   visibleCheck.onchange = function () {
-    nv1.setMeshProperty(nv1.meshes[0].id, 'visible', this.checked)
-  }
+    nv1.setMeshProperty(nv1.meshes[0].id, "visible", this.checked);
+  };
   function handleLocationChange(data) {
-    document.getElementById('location').innerHTML = '&nbsp;&nbsp;' + data.string
+    document.getElementById("location").innerHTML =
+      "&nbsp;&nbsp;" + data.string;
   }
   shaderSelect.onchange = function () {
-    nv1.setMeshShader(nv1.meshes[0].id, this.value)
-  }
+    nv1.setMeshShader(nv1.meshes[0].id, this.value);
+  };
   function handleMeshLoaded() {
-    let str = `Mesh has ${nv1.meshes[0].pts.length / 3} vertices and ${nv1.meshes[0].tris.length / 3} triangles`
-    if (startTime)
-      str += ` ${Date.now() - startTime}ms`
-    document.getElementById('location').innerHTML = str
-    console.log(str)
-    shaderSelect.onchange()
-    startTime = null
+    let str = `Mesh has ${nv1.meshes[0].pts.length / 3} vertices and ${
+      nv1.meshes[0].tris.length / 3
+    } triangles`;
+    if (startTime) str += ` ${Date.now() - startTime}ms`;
+    document.getElementById("location").innerHTML = str;
+    console.log(str);
+    shaderSelect.onchange();
+    startTime = null;
   }
   const defaults = {
     onMeshLoaded: handleMeshLoaded,
     onLocationChange: handleLocationChange,
     backColor: [1, 1, 1, 1],
-    show3Dcrosshair: true
-  }
-  const nv1 = new Niivue(defaults)
-  nv1.attachToCanvas(gl1)
-  nv1.isAlphaClipDark = true
+    show3Dcrosshair: true,
+  };
+  const nv1 = new Niivue(defaults);
+  nv1.attachToCanvas(gl1);
+  nv1.isAlphaClipDark = true;
   nv1.onImageLoaded = () => {
-    saveBtn.disabled = true
-    const otsu = nv1.findOtsu(3)
+    saveBtn.disabled = true;
+    const otsu = nv1.findOtsu(3);
     isoLabel.textContent =
-      'Isosurface Threshold (' +
+      "Isosurface Threshold (" +
       formatNumber(nv1.volumes[0].cal_min) +
-      '...' +
+      "..." +
       formatNumber(nv1.volumes[0].cal_max) +
-      ')'
-    isoNumber.value = formatNumber(otsu[1])
-    const str = `Image has ${nv1.volumes[0].dims[1]}×${nv1.volumes[0].dims[2]}×${nv1.volumes[0].dims[3]} voxels`
-    document.getElementById('location').innerHTML = str
-    nv1.setSliceType(nv1.sliceTypeMultiplanar)
-    console.log('ct2print 20241218 intensity range ' + isoLabel.textContent + ' threshold ' + isoNumber.value)
-  }
-  nv1.setClipPlane([0.1, 0, 120])
-  nv1.opts.dragMode = nv1.dragModes.pan
-  nv1.setRenderAzimuthElevation(245, 15)
-  nv1.opts.multiplanarForceRender = true
-  nv1.opts.yoke3Dto2DZoom = true
-  nv1.setInterpolation(true)
-  await nv1.loadVolumes([{ url: './tinyT1.nii.gz' }])
+      ")";
+    isoNumber.value = formatNumber(otsu[1]);
+    const str = `Image has ${nv1.volumes[0].dims[1]}×${nv1.volumes[0].dims[2]}×${nv1.volumes[0].dims[3]} voxels`;
+    document.getElementById("location").innerHTML = str;
+    nv1.setSliceType(nv1.sliceTypeMultiplanar);
+    console.log(
+      "ct2print 20241218 intensity range " +
+        isoLabel.textContent +
+        " threshold " +
+        isoNumber.value
+    );
+  };
+  nv1.setClipPlane([0.1, 0, 120]);
+  nv1.opts.dragMode = nv1.dragModes.pan;
+  nv1.setRenderAzimuthElevation(245, 15);
+  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.yoke3Dto2DZoom = true;
+  nv1.setInterpolation(true);
+  await nv1.loadVolumes([{ url: "./tinyT1.nii.gz" }]);
 }
 
-main()
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ct2print",
       "version": "0.1.0",
       "dependencies": {
-        "@itk-wasm/cuberille": "^0.1.0",
+        "@itk-wasm/cuberille": "^0.2.0",
         "@itk-wasm/mesh-filters": "^0.1.0",
         "@niivue/cbor-loader": "^1.1.0",
         "@niivue/niivue": "^0.44.2",
@@ -539,10 +539,9 @@
       }
     },
     "node_modules/@itk-wasm/cuberille": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@itk-wasm/cuberille/-/cuberille-0.1.0.tgz",
-      "integrity": "sha512-ftbGcnMkEBmIDO2s95AJFXEL9DwnR0XtaH0I0+mAdHo/JggNw5/gKbViGod7TDwm+9Y+ZRXqBaCjGc6372bgWw==",
-      "license": "Apache-2.0",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@itk-wasm/cuberille/-/cuberille-0.2.0.tgz",
+      "integrity": "sha512-8yXqAiIchswnMvILxOXM67p+H6zAUil/Rd5SFitjCD7XnMR9edpTNzQ/BEsLiaTlyVxGPnjv3QX4px43ZlRegA==",
       "dependencies": {
         "itk-wasm": "1.0.0-b.184"
       }
@@ -3474,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.2.0.tgz",
       "integrity": "sha512-ytMrKdR9iWEYHbUxs6x53m+MRl4SJsOSoMu1U1+Pfg0DjPeMlsRVx3RR5jvoonineDquIue83Oq69JvNsFSU5w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@itk-wasm/cuberille": "^0.1.0",
+    "@itk-wasm/cuberille": "^0.2.0",
     "@itk-wasm/mesh-filters": "^0.1.0",
     "@niivue/cbor-loader": "^1.1.0",
     "@niivue/niivue": "^0.44.2",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,27 +1,47 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from "vite";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 
 export default defineConfig({
-  root: '.',
-  base: './',
+  root: ".",
+  base: "./",
   server: {
-    open: 'index.html',
+    open: "index.html",
     headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
     },
   },
   build: {
     rollupOptions: {
       output: {
-        format: 'es'
-      }
-    }
+        format: "es",
+      },
+    },
   },
   worker: {
-    format: 'esm'
+    format: "esm",
   },
   // exclude @niivue/niimath from optimization
   optimizeDeps: {
-    exclude: ['@niivue/niimath']
-  }
-})
+    exclude: [
+      "@niivue/niimath",
+      "@itk-wasm/cuberille",
+      "@itk-wasm/mesh-filters",
+    ],
+  },
+  plugins: [
+    // put lazy loaded JavaScript and Wasm bundles in dist directory
+    viteStaticCopy({
+      targets: [
+        {
+          src: "node_modules/@itk-wasm/cuberille/dist/pipelines/*.{js,wasm,wasm.zst}",
+          dest: "pipelines",
+        },
+        {
+          src: "node_modules/@itk-wasm/mesh-filters/dist/pipelines/*.{js,wasm,wasm.zst}",
+          dest: "pipelines",
+        },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
- add to vite exclude so it picks up the web workers properly
- add vite static copy plugin configuration to vendor wasm modules
- call with cuberille instead of antiAliasCuberille -- the latter is for binary segmentation inputs
- Pass the isoSurfaceValue parameter and use a fixed version of @itk-wasm/cuberille that accepts this correctly :-)