### PR TITLE
Specify minimumComponentArea when repairing

### DIFF
--- a/main.js
+++ b/main.js
@@ -249,16 +249,20 @@ async function main() {
     itkImage.size = itkImage.size.map(Number)
     const { mesh } = await cuberille(itkImage, { isoSurfaceValue: isoValueRaw })
     meshProcessingMsg.textContent = "Generating manifold"
+    const minimumComponentArea = 1.0
+    const maximumHoleArea = 10.0
     const { outputMesh: repairedMesh } = await repair(mesh, {
-      maximumHoleArea: 50.0,
+      maximumHoleArea,
+      minimumComponentArea,
     })
     let initialMesh = repairedMesh
     if (largestCheck.checked) {
       console.log('Only retaining largest mesh')
       meshProcessingMsg.textContent = "Keep largest mesh component"
-      const { outputMesh: initialMesh } = await keepLargestComponent(
+      const { outputMesh: largestComponentMesh } = await keepLargestComponent(
         repairedMesh
       )
+      initialMesh = largestComponentMesh
     }
     while (nv1.meshes.length > 0) {
       nv1.removeMesh(nv1.meshes[0])
@@ -279,7 +283,7 @@ async function main() {
       newtonIterations: smooth,
       numberPoints: shrink,
     })
-    const { outputMesh: smoothedRepairedMesh } = await repair(smoothedMesh, { maximumHoleArea: 50.0 })
+    const { outputMesh: smoothedRepairedMesh } = await repair(smoothedMesh, { maximumHoleArea, minimumComponentArea })
     const niiMesh = iwm2meshCore(smoothedRepairedMesh)
     loadingCircle.classList.add("hidden")
     meshProcessingMsg.classList.add("hidden")


### PR DESCRIPTION
From the default 3 percent to 1 percent. This retains the iguana dataset eye socket bones.

Also reduce maximumHoleArea to 10 percent.

Set initialMesh via second variable due new const declaration.

Result:

![Screenshot 2024-12-30 110850](https://github.com/user-attachments/assets/6d3c8ed3-f05a-4a8b-b8b4-d6126e911f21)
